### PR TITLE
fixed case where ASIN exists but not in a listed offer

### DIFF
--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -263,7 +263,7 @@ class MWSClient{
 
         $array = [];
         foreach ($response as $product) {
-            if (isset($product['@attributes']['status']) && $product['@attributes']['status'] == 'Success') {
+            if (isset($product['@attributes']['status']) && $product['@attributes']['status'] == 'Success'  && isset($product['Product']['Offers']['Offer'])) {
                 $array[$product['@attributes']['ASIN']] = $product['Product']['Offers']['Offer'];
             } else {
                 $array[$product['@attributes']['ASIN']] = false;


### PR DESCRIPTION
ran into the case where offers array was empty:


 ```
   [10] => Array
        (
            [@attributes] => Array
                (
                    [ASIN] => B001DXC38K
                    [status] => Success
                )

            [Product] => Array
                (
                    [Identifiers] => Array
                        (
                            [MarketplaceASIN] => Array
                                (
                                    [MarketplaceId] => ATVPDKIKX0DER
                                    [ASIN] => B001DXC38K
                                )

                        )

                    [Offers] => Array
                        (
                        )

                )

        )

    [11] => Array
        (
            [@attributes] => Array
                (
                    [ASIN] => B001DX9W5C
                    [status] => Success
                )

            [Product] => Array
                (
                    [Identifiers] => Array
                        (
                            [MarketplaceASIN] => Array
                                (
                                    [MarketplaceId] => ATVPDKIKX0DER
                                    [ASIN] => B001DX9W5C
                                )

                        )

                    [Offers] => Array
```