### PR TITLE
Fix Signature as guzzle uses RFC3986

### DIFF
--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -1026,7 +1026,7 @@ class MWSClient{
                     . "\n"
                     . $endPoint['path']
                     . "\n"
-                    . http_build_query($query),
+                    . http_build_query($query, null, '&', PHP_QUERY_RFC3986),
                     $this->config['Secret_Access_Key'],
                     true
                 )


### PR DESCRIPTION
Before I made this I got an error:
`Exception 'Exception' with message 'The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.'` for trying to call `GetMatchingProductForId([$sku], 'SellerSKU')`.
Now everything is fine