### PR TITLE
Check MWSAuthToken is filled before add to query

### DIFF
--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -932,7 +932,7 @@ class MWSClient{
      * @param boolean $debug Return the generated xml and don't send it to amazon
      * @return array
      */
-    public function SubmitFeed($FeedType, $feedContent, $debug = false)
+    public function SubmitFeed($FeedType, $feedContent, $debug = false, $options = [])
     {
 
         if (is_array($feedContent)) {
@@ -953,9 +953,11 @@ class MWSClient{
             return $feedContent;
         }
 
+	$purgeAndReplace = isset($options['PurgeAndReplace']) ? $options['PurgeAndReplace'] : false;
+	    
         $query = [
             'FeedType' => $FeedType,
-            'PurgeAndReplace' => 'true',
+            'PurgeAndReplace' => ($purgeAndReplace ? 'true' : 'false'),
             'Merchant' => $this->config['Seller_Id'],
             'MarketplaceId.Id.1' => false,
             'SellerId' => false,
@@ -1154,7 +1156,7 @@ class MWSClient{
             $query['MarketplaceId.Id.1'] = $this->config['Marketplace_Id'];
         }
 
-        if (!is_null($this->config['MWSAuthToken']) AND $this->config['MWSAuthToken'] != "") {
+        if (!is_null($this->config['MWSAuthToken']) and $this->config['MWSAuthToken'] != "") {
             $query['MWSAuthToken'] = $this->config['MWSAuthToken'];
         }
 

--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -955,7 +955,7 @@ class MWSClient{
 
         $query = [
             'FeedType' => $FeedType,
-            'PurgeAndReplace' => 'false',
+            'PurgeAndReplace' => 'true',
             'Merchant' => $this->config['Seller_Id'],
             'MarketplaceId.Id.1' => false,
             'SellerId' => false,
@@ -1154,7 +1154,7 @@ class MWSClient{
             $query['MarketplaceId.Id.1'] = $this->config['Marketplace_Id'];
         }
 
-        if (!is_null($this->config['MWSAuthToken'])) {
+        if (!is_null($this->config['MWSAuthToken']) AND $this->config['MWSAuthToken'] != "") {
             $query['MWSAuthToken'] = $this->config['MWSAuthToken'];
         }
 


### PR DESCRIPTION
If MWSAuthToken is an empty string and gets added to query it will throw an error as Amazon tries to validate. This fix checks if MWSAuthToken is an empty string before adding it to query.