### PR TITLE
Allows additional, supported fields of MWSProduct to be used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ xml.xml
 xsd/
 documentor.php
 test.csv
+.idea/

--- a/src/Exceptions/RequestThrottled.php
+++ b/src/Exceptions/RequestThrottled.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace MCS\Exceptions;
+
+use Exception;
+
+class RequestThrottled extends Exception {
+    //
+}

--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -1314,7 +1314,7 @@ class MWSClient{
     /**
      * Request MWS
      */
-    private function request($endPoint, array $query = [], $body = null, $raw = false)
+    public function request($endPoint, array $query = [], $body = null, $raw = false)
     {
 
         $endPoint = MWSEndPoint::get($endPoint);

--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -4,6 +4,7 @@ namespace MCS;
 use DateTime;
 use Exception;
 use DateTimeZone;
+use MCS\Exceptions\RequestThrottled;
 use MCS\MWSEndPoint;
 use League\Csv\Reader;
 use League\Csv\Writer;
@@ -1417,6 +1418,10 @@ class MWSClient{
                 if (strpos($message, '<ErrorResponse') !== false) {
                     $error = simplexml_load_string($message);
                     $message = $error->Error->Message;
+                }
+
+                if ($message == 'Request is throttled') {
+                    throw new RequestThrottled;
                 }
             } else {
                 $message = 'An error occured';

--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -388,9 +388,11 @@ class MWSClient{
         ];
 
         $counter = 1;
-        foreach ($states as $status) {
-            $query['OrderStatus.Status.' . $counter] = $status;
-            $counter = $counter + 1;
+        if ($states != ['All']) {
+            foreach ($states as $status) {
+                $query['OrderStatus.Status.' . $counter] = $status;
+                $counter = $counter + 1;
+            }
         }
 
         if ($allMarketplaces == true) {
@@ -401,14 +403,16 @@ class MWSClient{
             }
         }
 
-        if(is_array($FulfillmentChannels)){
-            $counter = 1;
-            foreach ( $FulfillmentChannels as $fulfillmentChannel ) {
-                $query['FulfillmentChannel.Channel.' . $counter] = $fulfillmentChannel;
-                $counter = $counter + 1;
+        if ($FulfillmentChannels != "All") {
+            if(is_array($FulfillmentChannels)){
+                $counter = 1;
+                foreach ( $FulfillmentChannels as $fulfillmentChannel ) {
+                    $query['FulfillmentChannel.Channel.' . $counter] = $fulfillmentChannel;
+                    $counter = $counter + 1;
+                }
+            } else {
+                $query['FulfillmentChannel.Channel.1'] = $FulfillmentChannels;
             }
-        } else {
-            $query['FulfillmentChannel.Channel.1'] = $FulfillmentChannels;
         }
 
         $response = $this->request(

--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -1046,6 +1046,45 @@ class MWSClient{
     }
 
     /**
+     * Post to update shipping information for an order (_POST_FLAT_FILE_FULFILLMENT_DATA_)
+     * @param $products
+     * @return array
+     */
+    public function updateShippingInformation($products) {
+
+        if (!is_array($products)) {
+            $products = [$products];
+        }
+
+        $csv = Writer::createFromFileObject(new SplTempFileObject());
+
+        $csv->setDelimiter("\t");
+        $csv->setInputEncoding('iso-8859-1');
+
+        $header = [
+            'order-id',
+            'order-item-id',
+            'quantity',
+            'ship-date',
+            'carrier-code',
+            'carrier-name',
+            'tracking-number',
+            'ship-method',
+        ];
+
+        $csv->insertOne($header);
+
+        foreach ($products as $product) {
+            $csv->insertOne(
+                array_values($product->toArray())
+            );
+        }
+
+        return $this->SubmitFeed('_POST_FLAT_FILE_FULFILLMENT_DATA_', $csv);
+
+    }
+
+    /**
      * Returns the feed processing report and the Content-MD5 header.
      * @param string $FeedSubmissionId
      * @return array

--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -101,6 +101,46 @@ class MWSClient{
         }
     }
 
+    public function ListFinancialEvents(
+        DateTime $postedAfter = null,
+        DateTime $postedBefore = null,
+        string $financialEventGroupId = null,
+        string $amazonOrderID = null,
+        int $maxResultsPerPage = 100
+    ) {
+        $query = [];
+
+        if (! is_null($postedAfter)) {
+            $query['PostedAfter'] = gmdate(self::DATE_FORMAT, $postedAfter->getTimestamp());
+        }
+        if (! is_null($postedBefore)) {
+            $query['PostedBefore'] = gmdate(self::DATE_FORMAT, $postedBefore->getTimestamp());
+        }
+        if (! is_null($financialEventGroupId)) {
+            $query['FinancialEventGroupId'] = $financialEventGroupId;
+        }
+        if (! is_null($amazonOrderID)) {
+            $query['AmazonOrderId'] = $amazonOrderID;
+        }
+        $query['MaxResultsPerPage'] = $maxResultsPerPage;
+
+        $response = $this->request(
+            'ListFinancialEvents',
+            $query
+        );
+
+        if (isset($response['ListFinancialEventsResult']['FinancialEvents'])) {
+            $response = $response['ListFinancialEventsResult']['FinancialEvents'];
+            if (array_keys($response) !== range(0, count($response) - 1)) {
+                $response = [$response];
+            }
+        } else {
+            return [];
+        }
+
+        return $response;
+    }
+
     /**
      * Returns the current competitive price of a product, based on ASIN.
      * @param array [$asin_array = []]

--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -129,8 +129,30 @@ class MWSClient{
             $query
         );
 
-        if (isset($response['ListFinancialEventsResult']['FinancialEvents'])) {
-            $response = $response['ListFinancialEventsResult']['FinancialEvents'];
+        if (isset($response['ListFinancialEventsResult'])) {
+            $response = $response['ListFinancialEventsResult'];
+            if (array_keys($response) !== range(0, count($response) - 1)) {
+                $response = [$response];
+            }
+        } else {
+            return [];
+        }
+
+        return $response;
+    }
+
+    public function ListFinancialEventsByNextToken(string $nextToken) {
+        $query = [
+            'NextToken' => $nextToken
+        ];
+
+        $response = $this->request(
+            'ListFinancialEventsByNextToken',
+            $query
+        );
+
+        if (isset($response['ListFinancialEventsByNextTokenResult'])) {
+            $response = $response['ListFinancialEventsByNextTokenResult'];
             if (array_keys($response) !== range(0, count($response) - 1)) {
                 $response = [$response];
             }

--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -439,15 +439,17 @@ class MWSClient{
      * @param boolean $allMarketplaces , list orders from all marketplaces
      * @param array $states , an array containing orders states you want to filter on
      * @param string $FulfillmentChannels
+     * @param int $MaxResultsPerPage
      * @return array
      * @internal param string $FulfillmentChannel
      */
     public function ListOrdersByLastUpdate(DateTime $from, $allMarketplaces = false, $states = [
         'All',
-    ], $FulfillmentChannels = 'All')
+    ], $FulfillmentChannels = 'All', $MaxResultsPerPage = 100)
     {
         $query = [
-            'LastUpdatedAfter' => gmdate(self::DATE_FORMAT, $from->getTimestamp())
+            'LastUpdatedAfter' => gmdate(self::DATE_FORMAT, $from->getTimestamp()),
+            'MaxResultsPerPage' => $MaxResultsPerPage,
         ];
 
         $counter = 1;

--- a/src/MWSEndPoint.php
+++ b/src/MWSEndPoint.php
@@ -152,6 +152,12 @@ class MWSEndPoint{
             'path' => '/Finances/2015-05-01',
             'date' => '2015-05-01',
         ],
+        'ListFinancialEventsByNextToken' => [
+            'method' => 'POST',
+            'action' => 'ListFinancialEventsByNextToken',
+            'path' => '/Finances/2015-05-01',
+            'date' => '2015-05-01'
+        ],
     ];
 
     public static function get($key)

--- a/src/MWSEndPoint.php
+++ b/src/MWSEndPoint.php
@@ -145,7 +145,13 @@ class MWSEndPoint{
             'action' => 'GetLowestPricedOffersForASIN',
             'path' => '/Products/2011-10-01',
             'date' => '2011-10-01'
-        ]
+        ],
+        'ListFinancialEvents' => [
+            'method' => 'POST',
+            'action' => 'ListFinancialEvents',
+            'path' => '/Finances/2015-05-01',
+            'date' => '2015-05-01',
+        ],
     ];
 
     public static function get($key)

--- a/src/MWSProduct.php
+++ b/src/MWSProduct.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 namespace MCS;
 
 use Exception;
@@ -12,26 +12,44 @@ class MWSProduct{
     public $product_id_type;
     public $condition_type = 'New';
     public $condition_note;
-    
+    public $asin_hint;
+    public $title;
+    public $product_tax_code;
+    public $operation_type;
+    public $sale_price;
+    public $sale_start_date;
+    public $sale_end_date;
+    public $leadtime_to_ship;
+    public $launch_date;
+    public $is_giftwrap_available;
+    public $is_gift_message_available;
+    public $fulfillment_center_id;
+    public $main_offer_image;
+    public $offer_image1;
+    public $offer_image2;
+    public $offer_image3;
+    public $offer_image4;
+    public $offer_image5;
+
     private $validation_errors = [];
-    
+
     private $conditions = [
-        'New', 'Refurbished', 'UsedLikeNew', 
+        'New', 'Refurbished', 'UsedLikeNew',
         'UsedVeryGood', 'UsedGood', 'UsedAcceptable'
     ];
-    
+
     public function __construct(array $array = [])
     {
         foreach ($array as $property => $value) {
             $this->{$property} = $value;
         }
     }
-    
+
     public function getValidationErrors()
     {
-        return $this->validation_errors;   
+        return $this->validation_errors;
     }
-    
+
     public function toArray()
     {
         return [
@@ -42,77 +60,95 @@ class MWSProduct{
             'product_id_type' => $this->product_id_type,
             'condition_type' => $this->condition_type,
             'condition_note' => $this->condition_note,
+            'asin_hint' => $this->asin_hint,
+            'title' => $this->title,
+            'product_tax_code' => $this->product_tax_code,
+            'operation_type' => $this->operation_type,
+            'sale_price' => $this->sale_price,
+            'sale_start_date' => $this->sale_start_date,
+            'sale_end_date' => $this->sale_end_date,
+            'leadtime_to_ship' => $this->leadtime_to_ship,
+            'launch_date' => $this->launch_date,
+            'is_giftwrap_available' => $this->is_giftwrap_available,
+            'is_gift_message_available' => $this->is_gift_message_available,
+            'fulfillment_center_id' => $this->fulfillment_center_id,
+            'main_offer_image' => $this->main_offer_image,
+            'offer_image1' => $this->offer_image1,
+            'offer_image2' => $this->offer_image2,
+            'offer_image3' => $this->offer_image3,
+            'offer_image4' => $this->offer_image4,
+            'offer_image5' => $this->offer_image5,
         ];
     }
-    
+
     public function validate()
     {
         if (mb_strlen($this->sku) < 1 or strlen($this->sku) > 40) {
             $this->validation_errors['sku'] = 'Should be longer then 1 character and shorter then 40 characters';
         }
-        
+
         $this->price = str_replace(',', '.', $this->price);
-        
+
         $exploded_price = explode('.', $this->price);
-        
+
         if (count($exploded_price) == 2) {
-            if (mb_strlen($exploded_price[0]) > 18) { 
-                $this->validation_errors['price'] = 'Too high';        
+            if (mb_strlen($exploded_price[0]) > 18) {
+                $this->validation_errors['price'] = 'Too high';
             } else if (mb_strlen($exploded_price[1]) > 2) {
-                $this->validation_errors['price'] = 'Too many decimals';    
+                $this->validation_errors['price'] = 'Too many decimals';
             }
         } else {
-            $this->validation_errors['price'] = 'Looks wrong';        
+            $this->validation_errors['price'] = 'Looks wrong';
         }
-        
+
         $this->quantity = (int) $this->quantity;
         $this->product_id = (string) $this->product_id;
-        
+
         $product_id_length = mb_strlen($this->product_id);
-        
+
         switch ($this->product_id_type) {
             case 'ASIN':
                 if ($product_id_length != 10) {
-                    $this->validation_errors['product_id'] = 'ASIN should be 10 characters long';                
+                    $this->validation_errors['product_id'] = 'ASIN should be 10 characters long';
                 }
                 break;
             case 'UPC':
                 if ($product_id_length != 12) {
-                    $this->validation_errors['product_id'] = 'UPC should be 12 characters long';                
+                    $this->validation_errors['product_id'] = 'UPC should be 12 characters long';
                 }
                 break;
             case 'EAN':
                 if ($product_id_length != 13) {
-                    $this->validation_errors['product_id'] = 'EAN should be 13 characters long';                
+                    $this->validation_errors['product_id'] = 'EAN should be 13 characters long';
                 }
                 break;
             default:
-               $this->validation_errors['product_id_type'] = 'Not one of: ASIN,UPC,EAN';        
+                $this->validation_errors['product_id_type'] = 'Not one of: ASIN,UPC,EAN';
         }
-        
+
         if (!in_array($this->condition_type, $this->conditions)) {
-            $this->validation_errors['condition_type'] = 'Not one of: ' . implode($this->conditions, ',');                
+            $this->validation_errors['condition_type'] = 'Not one of: ' . implode($this->conditions, ',');
         }
-        
+
         if ($this->condition_type != 'New') {
             $length = mb_strlen($this->condition_note);
             if ($length < 1) {
-                $this->validation_errors['condition_note'] = 'Required if condition_type not is New';                    
+                $this->validation_errors['condition_note'] = 'Required if condition_type not is New';
             } else if ($length > 1000) {
-                $this->validation_errors['condition_note'] = 'Should not exceed 1000 characters';                    
+                $this->validation_errors['condition_note'] = 'Should not exceed 1000 characters';
             }
         }
-        
+
         if (count($this->validation_errors) > 0) {
-            return false;    
+            return false;
         } else {
-            return true;    
+            return true;
         }
     }
-    
+
     public function __set($property, $value) {
         if (property_exists($this, $property)) {
             return $this->$property;
         }
-    }    
+    }
 }


### PR DESCRIPTION
This PR introduces a fix to allow the additional, supported fields of the MWSProduct to be used when creating a report.

It does this by:
- Creating the necessary public variables, so they can be set properly due to the `__set` magic method preventing non declared variables from being set
- Adding these new fields in their proper order to the `toArray` method