### PR TITLE
Add end of time frame for listing orders

### DIFF
--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -383,14 +383,14 @@ class MWSClient{
         'Unshipped', 'PartiallyShipped'
     ], $FulfillmentChannels = 'MFN', DateTime $till = null)
     {
-        if ($till == null) {
-          $till = new DateTime('now');
-        }
 
         $query = [
-            'CreatedAfter' => gmdate(self::DATE_FORMAT, $from->getTimestamp()),
-            'CreatedBefore' => gmdate(self::DATE_FORMAT, $till->getTimestamp())
+            'CreatedAfter' => gmdate(self::DATE_FORMAT, $from->getTimestamp())
         ];
+
+        if ($till !== null) {
+          $query['CreatedBefore'] = gmdate(self::DATE_FORMAT, $till->getTimestamp());
+        }
 
         $counter = 1;
         foreach ($states as $status) {

--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -383,7 +383,6 @@ class MWSClient{
         'Unshipped', 'PartiallyShipped'
     ], $FulfillmentChannels = 'MFN', DateTime $till = null)
     {
-
         $query = [
             'CreatedAfter' => gmdate(self::DATE_FORMAT, $from->getTimestamp())
         ];

--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -372,18 +372,24 @@ class MWSClient{
 
     /**
      * Returns orders created or updated during a time frame that you specify.
-     * @param object DateTime $from
+     * @param object DateTime $from, beginning of time frame
      * @param boolean $allMarketplaces, list orders from all marketplaces
      * @param array $states, an array containing orders states you want to filter on
      * @param string $FulfillmentChannel
+     * @param object DateTime $till, end of time frame
      * @return array
      */
     public function ListOrders(DateTime $from, $allMarketplaces = false, $states = [
         'Unshipped', 'PartiallyShipped'
-    ], $FulfillmentChannels = 'MFN')
+    ], $FulfillmentChannels = 'MFN', DateTime $till = null)
     {
+        if ($till == null) {
+          $till = new DateTime('now');
+        }
+
         $query = [
-            'CreatedAfter' => gmdate(self::DATE_FORMAT, $from->getTimestamp())
+            'CreatedAfter' => gmdate(self::DATE_FORMAT, $from->getTimestamp()),
+            'CreatedBefore' => gmdate(self::DATE_FORMAT, $till->getTimestamp())
         ];
 
         $counter = 1;


### PR DESCRIPTION
It was not possible before, to provide an upper limit to the time frame for fetching orders. Only a lower limit was possible. To be able to actually give a time frame I added the upper limit as an optional parameter to stay backwards compatible.