### PR TITLE
Add check for Access_Key_Id in config to normalise the "ID" keys

### DIFF
--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -50,7 +50,12 @@ class MWSClient{
     public function __construct(array $config)
     {
 
-        foreach($config as $key => $value) {
+	    if (isset($config['Access_Key_Id']) && !isset($config['Access_Key_ID'])) {
+		    $config['Access_Key_ID'] = $config['Access_Key_Id'];
+		    unset($config['Access_Key_Id']);
+	    }
+
+	    foreach($config as $key => $value) {
             if (array_key_exists($key, $this->config)) {
                 $this->config[$key] = $value;
             }
@@ -145,7 +150,7 @@ class MWSClient{
         return $array;
 
     }
-    
+
         /**
      * Returns the current competitive price of a product, based on SKU.
      * @param array [$sku_array = []]
@@ -423,15 +428,15 @@ class MWSClient{
                 $data['NextToken'] = $response['ListOrdersResult']['NextToken'];
                 return $data;
             }
-        
+
             $response = $response['ListOrdersResult']['Orders']['Order'];
-        
+
             if (array_keys($response) !== range(0, count($response) - 1)) {
                 return [$response];
             }
-        
+
             return $response;
-        
+
         } else {
             return [];
         }
@@ -995,7 +1000,7 @@ class MWSClient{
         }
 
 	$purgeAndReplace = isset($options['PurgeAndReplace']) ? $options['PurgeAndReplace'] : false;
-	    
+
         $query = [
             'FeedType' => $FeedType,
             'PurgeAndReplace' => ($purgeAndReplace ? 'true' : 'false'),
@@ -1132,7 +1137,7 @@ class MWSClient{
         return false;
 
     }
-    
+
     /**
 	 * Get a list's inventory for Amazon's fulfillment
 	 *
@@ -1142,33 +1147,33 @@ class MWSClient{
 	 * @throws Exception
 	 */
     public function ListInventorySupply($sku_array = []){
-	
+
 	    if (count($sku_array) > 50) {
 		    throw new Exception('Maximum amount of SKU\'s for this call is 50');
 	    }
-	
+
 	    $counter = 1;
 	    $query = [
 		    'MarketplaceId' => $this->config['Marketplace_Id']
 	    ];
-	
+
 	    foreach($sku_array as $key){
 		    $query['SellerSkus.member.' . $counter] = $key;
 		    $counter++;
 	    }
-	
+
 	    $response = $this->request(
 		    'ListInventorySupply',
 		    $query
 	    );
-	
+
 	    $result = [];
 	    if (isset($response['ListInventorySupplyResult']['InventorySupplyList']['member'])) {
 		    foreach ($response['ListInventorySupplyResult']['InventorySupplyList']['member'] as $index => $ListInventorySupplyResult) {
 			    $result[$index] = $ListInventorySupplyResult;
 		    }
 	    }
-	    
+
 	    return $result;
     }
 
@@ -1250,7 +1255,7 @@ class MWSClient{
             );
 
             $requestOptions['query'] = $query;
-            
+
             if($this->client === NULL) {
                 $this->client = new Client();
             }
@@ -1288,7 +1293,7 @@ class MWSClient{
             throw new Exception($message);
         }
     }
-    
+
     public function setClient(Client $client) {
         $this->client = $client;
     }


### PR DESCRIPTION
Two of the three "ID" fields in the constructor's $config array use "Id" as the array key, where as the access key ID uses "ID".

I assume this is because of an inconsistency in the Amazon MWS API, but it seems like it would make sense to allow the user to pass "Access_Key_Id" to be consistent with the other two keys, and have the constructor translate this to the correct key.