### PR TITLE
Fix - Change in Amazon Order Not Valid Message

### DIFF
--- a/src/MWSClient.php
+++ b/src/MWSClient.php
@@ -18,6 +18,7 @@ class MWSClient{
     const SIGNATURE_VERSION = '2';
     const DATE_FORMAT = "Y-m-d\TH:i:s.\\0\\0\\0\\Z";
     const APPLICATION_NAME = 'MCS/MwsClient';
+    const ORDER_ID_NOT_VALID = 'The order id you have requested is not valid.';
 
     private $config = [
         'Seller_Id' => null,
@@ -93,7 +94,7 @@ class MWSClient{
         try{
             $this->ListOrderItems('validate');
         } catch(Exception $e) {
-            if ($e->getMessage() == 'Invalid AmazonOrderId: validate') {
+            if ($e->getMessage() == self::ORDER_ID_NOT_VALID) {
                 return true;
             } else {
                 return false;


### PR DESCRIPTION
I am not allowed to submit feeds or make any other operation with the Amazon MWS as the error message in validateCredentials method has changed.

![image](https://user-images.githubusercontent.com/26056898/75025916-4eafd900-549c-11ea-9145-ad5808a3e614.png)
